### PR TITLE
Tell sqlite3.connect that we're passing a URI

### DIFF
--- a/prometheus_rasdaemon_exporter/rasdaemon_exporter.py
+++ b/prometheus_rasdaemon_exporter/rasdaemon_exporter.py
@@ -154,7 +154,9 @@ def main():
     args = parser.parse_args()
 
     try:
-        DB = sqlite3.connect(f"file:{args.db}?mode=ro", check_same_thread=False)
+        DB = sqlite3.connect(
+            f"file:{args.db}?mode=ro", check_same_thread=False, uri=True
+        )
     except sqlite3.OperationalError as e:
         print(f"Cannot connect to {args.db}: {e}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
Otherwise `file:` is going to be treated as part of a relative path.

https://docs.python.org/3/library/sqlite3.html#how-to-work-with-sqlite-uris


```bash
# strace -e trace=file prometheus-rasdaemon-exporter --db /var/lib/rasdaemon/ras-mc_event.db
[...]
getcwd("/root", 4096)                   = 6
newfstatat(AT_FDCWD, "/root", {st_mode=S_IFDIR|0700, st_size=19, ...}, AT_SYMLINK_NOFOLLOW) = 0
newfstatat(AT_FDCWD, "/root/file:", 0x7ffc76f100d0, AT_SYMLINK_NOFOLLOW) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/root/file:/var", 0x7ffc76f100d0, AT_SYMLINK_NOFOLLOW) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/root/file:/var/lib", 0x7ffc76f100d0, AT_SYMLINK_NOFOLLOW) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/root/file:/var/lib/rasdaemon", 0x7ffc76f100d0, AT_SYMLINK_NOFOLLOW) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/root/file:/var/lib/rasdaemon/ras-mc_event.db?mode=ro", 0x7ffc76f100d0, AT_SYMLINK_NOFOLLOW) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/root/file:/var/lib/rasdaemon/ras-mc_event.db?mode=ro", O_RDWR|O_CREAT|O_NOFOLLOW|O_CLOEXEC, 0644) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/root/file:/var/lib/rasdaemon/ras-mc_event.db?mode=ro", O_RDONLY|O_NOFOLLOW|O_CLOEXEC) = -1 ENOENT (No such file or directory)
Cannot connect to /var/lib/rasdaemon/ras-mc_event.db: unable to open database file